### PR TITLE
fix: call collectJobCompletions after discover

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -62,11 +62,12 @@ export async function makeServer(opts: Options): Promise<express.Application> {
     prefix: opts.prefix,
     autoDiscover: opts.autoDiscover,
   });
-  collector.collectJobCompletions();
 
   if (opts.autoDiscover) {
     await collector.discoverAll();
   }
+
+  collector.collectJobCompletions();
 
   app.post('/discover_queues', (_req: express.Request, res: express.Response, next: express.NextFunction) => {
     collector.discoverAll()


### PR DESCRIPTION
### Description
Duration metric doesn't work when you use auto discover for queues

### This is a 
- [x] Bug Fix
