### PR TITLE
fix: Prometheus image link is broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 <p align="center">
   <a href="https://prometheus.io/">
-    <img src="https://upload.wikimedia.org/wikipedia/en/thumb/3/38/Prometheus_software_logo.svg/115px-Prometheus_software_logo.svg.png" height="115">
+    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/38/Prometheus_software_logo.svg/115px-Prometheus_software_logo.svg.png" height="115">
   </a>
   <a href="https://github.com/OptimalBits/bull">
     <img src="https://github.com/OptimalBits/bull/blob/develop/support/logo@2x.png" height="115" />


### PR DESCRIPTION
<!--
## Pull Request template
-->
### Description
Modest contribution to fix the broken link to the prometheus project in the Readme.

### This is a 
<!-- Pick One -->
- [ ] Bug Fix
- [ ] Feature
- [x] Documentation
- [ ] Other

## Checklists
#### Commit style
   <!-- Check all the following -->
   - [x] Changes are on a branch with a descriptive name eg. `fix/missing-queue`, `docs/setup-guide`
   
   - [x] Commits start with one of `feat:` `fix:` `docs:` `chore:` or similar
   
   - [x] No excessive commits, eg: there should be no `fix:` commits for bugs that existed only on the PR branch (see [guide-to-interactive-rebasing](https://hackernoon.com/beginners-guide-to-interactive-rebasing-346a3f9c3a6d))

#### Protected files

The following files should not change unless they are directly a part of your change.
    <!-- Check any of the bellow files that have changed, add a reason for each if nessesary  -->
   - [ ] `yarn.lock` (unless package.json is also modified, then only the new/updated package should be changed here)
   
   - [ ] `package.json` (renovate bot should handle all routine updates)

   - [ ] `package-lock.json` (Should not exist as this project uses yarn)
   
   - [ ] `tsconfig.json` (only make it stricter, making it more lenient requires more discussion)
   
   - [ ] `tslint.json` (only make it stricter, making it more lenient requires more discussion)
