### PR TITLE
docs: fix Prometheus metrics types in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ ___
 #### Prometheus
 **An existing prometheus server is required to use this project**
 
-To learn more about how to setup promethues and grafana see: https://eksworkshop.com/monitoring/
+To learn more about how to setup prometheus and grafana see: https://eksworkshop.com/monitoring/
 
 #### Grafana
 The dashboard pictured above is [available to download from grafana](https://grafana.com/grafana/dashboards/10128).

--- a/README.md
+++ b/README.md
@@ -39,26 +39,26 @@ this can also be triggered manually from the `/discover_queues` endpoint
 
 ## Metrics
 
-| Metric                       | type    | description |
-|------------------------------|---------|-------------|
-| bull_queue_completed         | counter | Total number of completed jobs                          |
-| bull_queue_complete_duration | summary | Processing time for completed jobs                      |
-| bull_queue_active            | counter | Total number of active jobs (currently being processed) |
-| bull_queue_delayed           | counter | Total number of jobs that will run in the future        |
-| bull_queue_failed            | counter | Total number of failed jobs                             |
-| bull_queue_waiting           | counter | Total number of jobs waiting to be processed            |
+| Metric                       | [type](1) | description                                             |
+| ---------------------------- | --------- | ------------------------------------------------------- |
+| bull_queue_completed         | gauge     | Total number of completed jobs                          |
+| bull_queue_complete_duration | summary   | Processing time for completed jobs                      |
+| bull_queue_active            | gauge     | Total number of active jobs (currently being processed) |
+| bull_queue_delayed           | gauge     | Total number of jobs that will run in the future        |
+| bull_queue_failed            | gauge     | Total number of failed jobs                             |
+| bull_queue_waiting           | gauge     | Total number of jobs waiting to be processed            |
 
 ## Kubernetes Usage
 
 ### Environment variables for default docker image
 
-| variable              | default                  | description                                     |
-|-----------------------|--------------------------|-------------------------------------------------|
-| EXPORTER_REDIS_URL    | redis://localhost:6379/0 | Redis uri to connect                            |
-| EXPORTER_PREFIX       | bull                     | prefix for queues                               |
-| EXPORTER_STAT_PREFIX  | bull_queue_              | prefix for exported metrics                     |
-| EXPORTER_QUEUES       | -                        | a space separated list of queues to check       |
-| EXPORTER_AUTODISCOVER | -                        | set to '0' or 'false' to disable queue discovery|
+| variable              | default                  | description                                      |
+| --------------------- | ------------------------ | ------------------------------------------------ |
+| EXPORTER_REDIS_URL    | redis://localhost:6379/0 | Redis uri to connect                             |
+| EXPORTER_PREFIX       | bull                     | prefix for queues                                |
+| EXPORTER_STAT_PREFIX  | bull_queue_              | prefix for exported metrics                      |
+| EXPORTER_QUEUES       | -                        | a space separated list of queues to check        |
+| EXPORTER_AUTODISCOVER | -                        | set to '0' or 'false' to disable queue discovery |
 
 
 ### Example deployment
@@ -137,3 +137,5 @@ spec:
     role: exporter
 
 ```
+
+[1]: https://prometheus.io/docs/concepts/metric_types


### PR DESCRIPTION
<!--
## Pull Request template
-->
### Description
Fix Prometheus metrics types in documentation according to the reality and add link to Prometheus metrics type documentation.

### This is a 
<!-- Pick One -->
- [ ] Bug Fix
- [ ] Feature
- [x] Documentation
- [ ] Other

## Checklists
#### Commit style
   <!-- Check all the following -->
   - [x] Changes are on a branch with a descriptive name eg. `fix/missing-queue`, `docs/setup-guide`
   
   - [x] Commits start with one of `feat:` `fix:` `docs:` `chore:` or similar
   
   - [x] No excessive commits, eg: there should be no `fix:` commits for bugs that existed only on the PR branch (see [guide-to-interactive-rebasing](https://hackernoon.com/beginners-guide-to-interactive-rebasing-346a3f9c3a6d))

#### Protected files

The following files should not change unless they are directly a part of your change.
    <!-- Check any of the bellow files that have changed, add a reason for each if necessary  -->
   - [ ] `yarn.lock` (unless package.json is also modified, then only the new/updated package should be changed here)
   
   - [ ] `package.json` (renovate bot should handle all routine updates)

   - [ ] `package-lock.json` (Should not exist as this project uses yarn)
   
   - [ ] `tsconfig.json` (only make it stricter, making it more lenient requires more discussion)
   
   - [ ] `tslint.json` (only make it stricter, making it more lenient requires more discussion)
