### PR TITLE
feat: Add Redis Sentinel connection support

### DIFF
--- a/setup/docker/main.sh
+++ b/setup/docker/main.sh
@@ -5,12 +5,16 @@ url="${EXPORTER_REDIS_URL:-redis://localhost:6379/0}"
 prefix="${EXPORTER_PREFIX:-bull}"
 metric_prefix="${EXPORTER_STAT_PREFIX:-bull_queue_}"
 queues="${EXPORTER_QUEUES:-}"
+sentinel_extra_endpoints="${EXPORTER_SENTINEL_EXTRA_ENDPOINTS:-}"
+sentinel_master_name="${EXPORTER_SENTINEL_MASTER_NAME:-}"
 EXPORTER_AUTODISCOVER="${EXPORTER_AUTODISCOVER:-}"
 
 flags=(
   --url "$url"
   --prefix "$prefix"
   --metric-prefix "$metric_prefix"
+  --sentinel-extra-endpoints EXPORTER_SENTINEL_EXTRA_ENDPOINTS --
+  --sentinel-master-name "$sentinel_master_name"
 )
 
 if [[ "$EXPORTER_AUTODISCOVER" != 0 && "$EXPORTER_AUTODISCOVER" != 'false' ]] ; then

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,8 @@ export async function printOnce(opts: Options): Promise<void> {
     logger,
     metricPrefix: opts.metricPrefix,
     redis: opts.url,
+    sentinelExtraEndpoints: opts.sentinelExtraEndpoints,
+    sentinelMasterName: opts.sentinelMasterName,
     prefix: opts.prefix,
     autoDiscover: opts.autoDiscover,
   });

--- a/src/options.ts
+++ b/src/options.ts
@@ -4,6 +4,8 @@ import { version } from '../package.json';
 
 export interface Options {
   url: string;
+  sentinelExtraEndpoints: string[];
+  sentinelMasterName: string;
   prefix: string;
   metricPrefix: string;
   once: boolean;
@@ -20,8 +22,19 @@ export function getOptionsFromArgs(...args: string[]): Options {
     .options({
       url: {
         alias: 'u',
-        describe: 'A redis connection url',
+        describe: 'A redis connection url. To connect to Redis Sentinel use "sentinel:" schema',
         default: 'redis://127.0.0.1:6379',
+        demandOption: true,
+      },
+      sentinelExtraEndpoints: {
+        describe: 'Extra host:port pairs for Redis Sentinel',
+        default: [],
+        array: true,
+        demandOption: true,
+      },
+      sentinelMasterName: {
+        describe: 'Redis Sentinel Master Name',
+        default: '',
         demandOption: true,
       },
       prefix: {

--- a/src/server.ts
+++ b/src/server.ts
@@ -59,6 +59,8 @@ export async function makeServer(opts: Options): Promise<express.Application> {
     logger,
     metricPrefix: opts.metricPrefix,
     redis: opts.url,
+    sentinelExtraEndpoints: opts.sentinelExtraEndpoints,
+    sentinelMasterName: opts.sentinelMasterName,
     prefix: opts.prefix,
     autoDiscover: opts.autoDiscover,
   });


### PR DESCRIPTION
### Description

Add support for Redis Sentinel via the following options:
- `--url sentinel://:mypass@sentinel.01:26379`
- `--sentinelExtraEndpoints sentinel.02:26379 sentinel.03:26379 --`, `--sentinel-extra-endpoints sentinel.02:26379 sentinel.03:26379 --`sentinel.03:26379 --`
- `--sentinelMasterName myredis`, `--sentinel-master-name myredis`

Add support of the new configuration options via the environment variables as well:
- `EXPORTER_SENTINEL_EXTRA_ENDPOINTS`
- `EXPORTER_SENTINEL_MASTER_NAME`

### This is a 

- [ ] Bug Fix
- [x] Feature
- [ ] Documentation
- [ ] Other

## Checklists
#### Commit style

   - [x] Changes are on a branch with a descriptive name eg. `fix/missing-queue`, `docs/setup-guide`
   
   - [x] Commits start with one of `feat:` `fix:` `docs:` `chore:` or similar
   
   - [x] No excessive commits, eg: there should be no `fix:` commits for bugs that existed only on the PR branch (see [guide-to-interactive-rebasing](https://hackernoon.com/beginners-guide-to-interactive-rebasing-346a3f9c3a6d))

#### Protected files

The following files should not change unless they are directly a part of your change.

   - [ ] `yarn.lock` (unless package.json is also modified, then only the new/updated package should be changed here)
   
   - [ ] `package.json` (renovate bot should handle all routine updates)

   - [ ] `package-lock.json` (Should not exist as this project uses yarn)
   
   - [ ] `tsconfig.json` (only make it stricter, making it more lenient requires more discussion)
   
   - [ ] `tslint.json` (only make it stricter, making it more lenient requires more discussion)
